### PR TITLE
[CI]: Fix publish distro to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,15 @@ jobs:
       - name: Check metadata verification
         run: python -m twine check --strict dist/*
 
+      - name: Upload artifact with distribution files
+        uses: actions/upload-artifact@v4
+        with:
+          name: distro-files
+          path: dist/
+          if-no-files-found: warn
+          retention-days: 1  # delete the artifact after 1 day, no need to keep it for too long
+          compression-level: 0  # no need to compress the files
+
   publish-distribution:
     name: Upload distribution to PyPI
     runs-on: ubuntu-latest
@@ -53,5 +62,11 @@ jobs:
       # permission mandatory for trusted publishing
       id-token: write
     steps:
+      - name: Download artifact with distribution files
+        uses: actions/download-artifact@v4
+        with:
+          name: distro-files
+          path: dist/
+
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+# This file defines which files should be included in the source distribution (.tar.gz)
+# and, in conjuntion with pyproject.toml, affects the files included in the wheel distribution (.whl)
+# See https://setuptools.pypa.io/en/latest/userguide/miscellaneous.html for reference [2024-10-25]
+
+# By default, all VCS-tracked files are included, so let's exclude unwanted files
+prune .github
+prune ci
+exclude .git*
+exclude .readthedocs.yaml

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,6 +51,13 @@ exclude_patterns = ["whatsnews/_next_release_template.rst"]
 # suppress unreferenced footnote warnings
 suppress_warnings = ["ref.footnote"]
 
+# rst Prolog is included at the beginning of every source file that is read.
+# This is useful for substitutions and other things that should be available in
+# every file, such as project-specific links.
+rst_prolog = """
+.. _PyPI_project: https://pypi.org/project/pvpltools/
+"""
+
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,6 +39,7 @@ extensions = [
     "sphinx_gallery.gen_gallery",
     "sphinx_toggleprompt",
     "sphinx_favicon",
+    "sphinx_copybutton",
 ]
 
 templates_path = ["templates"]

--- a/docs/contribute/contributing.rst
+++ b/docs/contribute/contributing.rst
@@ -170,12 +170,13 @@ follow these steps:
 0. Make sure changelog entries are up-to-date and the code is ready for release.
 1. Push a new tag with the version number and the pre-release suffix, e.g.,
    ``v0.1.0a1``.
-2. The GitHub Actions workflow will automatically publish the pre-release to PyPI. This is the most important step, as it will test the package installation.
+2. The GitHub Actions workflow will automatically publish the pre-release to PyPI. This is the most important step, as it will test the package installation. Check it gets published correctly on PyPI.
+   `PyPI project link <PyPI_project_>`_.
 3. (Optionally) Install the pre-release with pip:
 
-  .. code-block:: bash
+.. code-block:: bash
 
-      pip install --pre pvpltools
+    pip install --pre pvpltools
 
 4. (Optionally) Announce the pre-release, e.g., on the GitHub "Releases" tab. You may link to the pre-release on PyPI, the documentation or copy&paste the changelog.
 
@@ -186,12 +187,13 @@ To create a new release, follow these steps:
 
 0. Make sure changelog entries and it's filename are up-to-date and the code is ready for release.
 1. Push a new tag with the version number, e.g., ``v0.1.0``.
-2. The GitHub Actions workflow will automatically publish the release to PyPI.
+2. The GitHub Actions workflow will automatically publish the release to PyPI. Check it gets published correctly on PyPI.
+   `PyPI project link <PyPI_project_>`_.
 3. Install the release with pip:
 
-  .. code-block:: bash
+.. code-block:: bash
 
-      pip install pvpltools
+    pip install pvpltools
 
 4. Announce the release, e.g., on the GitHub "Releases" tab. You may link to the release on PyPI, the documentation or copy&paste the changelog.
 5. After the release, add a new section to the changelog, e.g., ``docs/whatsnews/0.1.1.rst`` and list it in ``docs/whatsnews/_index.rst`` via ``.. include:: 0.1.1.rst`` on top of the list, to preserve the chronological order. You may make a copy of the template ``docs/whatsnews/_next_release_template.rst`` and fill in the details.
@@ -208,4 +210,4 @@ For more information, you may want to check out:
 .. _release procedure: https://github.com/pvlib/pvlib-python/wiki/Release-procedures
 .. _keep_a_changelog_guide: https://keepachangelog.com/en/
 
-🌞*Have a bright coding day!*
+🌞 *Have a bright coding day!*

--- a/pvpltools/requirements.txt
+++ b/pvpltools/requirements.txt
@@ -1,3 +1,0 @@
-numpy
-pandas
-scipy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ docs = [
     "pydata-sphinx-theme~=0.15",
     "sphinx-gallery~=0.18",
     "sphinx_toggleprompt~=0.5",
-    "sphinx_favicon~=1.0"
+    "sphinx_favicon~=1.0",
+    "sphinx-copybutton~=0.5",
 ]
 all = ["pvpltools[test,docs]"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,16 @@ all = ["pvpltools[test,docs]"]
 "Bug Tracker" = "https://github.com/pvplabs/pvpltools/issues"
 "Changelog" = "https://pvpltools.readthedocs.io/en/latest/"
 
+# Control which files are included in the built distribution
+# https://setuptools.pypa.io/en/latest/userguide/datafiles.html [2024-10-25]
+[tool.setuptools]
+include-package-data = true  # inclusion of non-python files in the package folder (like data files) [default: true]
+[tool.setuptools.packages.find]
+include = ["pvpltools*"]
+exclude = ["pvpltools.test*"]
+[tool.setuptools.exclude-package-data]
+pvpltools = ["test/*"]  # exclude test folder from the package
+
 [tool.setuptools_scm]
 
 [tool.flake8]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,8 @@ all = ["pvpltools[test,docs]"]
 [project.urls]
 "Homepage" = "https://pvpltools.readthedocs.io/en/latest/"
 "Documentation" = "https://pvpltools.readthedocs.io/en/latest/"
-"Repository" = "https://github.com/pvlabs/pvpltools"
-"Bug Tracker" = "https://github.com/pvlabs/pvpltools/issues"
+"Repository" = "https://github.com/pvplabs/pvpltools"
+"Bug Tracker" = "https://github.com/pvplabs/pvpltools/issues"
 "Changelog" = "https://pvpltools.readthedocs.io/en/latest/"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
- CI fix: This will be tested "in production", at the moment a definitive version is tagged. I'm very positive on that it will work. [Source](https://github.com/pypa/gh-action-pypi-publish/tree/release/v1/?tab=readme-ov-file#non-goals).
- Project links fix
- Add `MANIFEST.in` and exclude tests/tests data from bdist (as pvlib-python#2277)
- Cleanup from old file, `requirements.txt` in pvpltools
- Add `PyPI_project` as an hyperlink to be used in all rST files, handy for maintenance reasons.
- Add `sphinx_copybutton` extension for code snippets buttons