### PR TITLE
[MAINT]: Add tests back to the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,9 +56,6 @@ all = ["pvpltools[test,docs]"]
 include-package-data = true  # inclusion of non-python files in the package folder (like data files) [default: true]
 [tool.setuptools.packages.find]
 include = ["pvpltools*"]
-exclude = ["pvpltools.test*"]
-[tool.setuptools.exclude-package-data]
-pvpltools = ["test/*"]  # exclude test folder from the package
 
 [tool.setuptools_scm]
 


### PR DESCRIPTION
Addressing @adriesse's comment:

https://github.com/pvplabs/pvpltools/pull/15#issuecomment-2452994545

I discourage against including them, branch `main` allows a place for test data that an end-user wouldn't need in their installs. Source always has the tests, so even in the rare case somebody needs them, they can extract the project from source distro. It's also fairly true that for the current size of the tests & their data (100kB), it's impact is negligible in download/install time.

It's up to you whether or not to merge this PR.

EDIT: you can revert back whenever you want, that's why I've made this stand-alone PR for that.